### PR TITLE
Adds environment parameter.

### DIFF
--- a/Source/Vima.LoggingAbstractor.AppInsights/AppInsightsAbstractLogger.cs
+++ b/Source/Vima.LoggingAbstractor.AppInsights/AppInsightsAbstractLogger.cs
@@ -102,6 +102,12 @@ namespace Vima.LoggingAbstractor.AppInsights
         {
             IEnumerable<ILoggingParameter> loggingParameters = parameters.ToList();
 
+            var environment = loggingParameters.ExtractEnvironment();
+            if (!string.IsNullOrEmpty(environment))
+            {
+                telemetry.Properties.Add("Environment", environment);
+            }
+
             var tagCount = 1;
             foreach (string tag in loggingParameters.ExtractTags())
             {

--- a/Source/Vima.LoggingAbstractor.Core/Extensions/LoggingParameterExtensions.cs
+++ b/Source/Vima.LoggingAbstractor.Core/Extensions/LoggingParameterExtensions.cs
@@ -84,5 +84,23 @@ namespace Vima.LoggingAbstractor.Core.Extensions
 
             return null;
         }
+
+        /// <summary>
+        /// Extracts the environment information.
+        /// </summary>
+        /// <param name="parameters">The parameters.</param>
+        /// <returns>Environment value.</returns>
+        public static string ExtractEnvironment(this IEnumerable<ILoggingParameter> parameters)
+        {
+            ILoggingParameter loggingParameter = parameters
+                .FirstOrDefault(x => x.LoggingParameterType == LoggingParameterType.Environment);
+
+            if (loggingParameter != null && loggingParameter is ILoggingParameter<string> environment)
+            {
+                return environment.Value;
+            }
+
+            return null;
+        }
     }
 }

--- a/Source/Vima.LoggingAbstractor.Core/Parameters/LoggingEnvironmentParameter.cs
+++ b/Source/Vima.LoggingAbstractor.Core/Parameters/LoggingEnvironmentParameter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace Vima.LoggingAbstractor.Core.Parameters
+{
+    /// <summary>
+    /// Represents logging environment parameter.
+    /// </summary>
+    public class LoggingEnvironmentParameter : ILoggingParameter<string>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoggingEnvironmentParameter"/> class.
+        /// </summary>
+        /// <param name="environment">The environment.</param>
+        public LoggingEnvironmentParameter(string environment)
+        {
+            Value = environment ?? throw new ArgumentNullException(nameof(environment));
+        }
+
+        /// <summary>
+        /// Gets the parameter's value.
+        /// </summary>
+        /// <value>
+        /// The parameter's value.
+        /// </value>
+        public string Value { get; }
+
+        /// <summary>
+        /// Gets the type of the logging parameter.
+        /// </summary>
+        /// <value>
+        /// The type of the logging parameter.
+        /// </value>
+        public LoggingParameterType LoggingParameterType => LoggingParameterType.Environment;
+    }
+}

--- a/Source/Vima.LoggingAbstractor.Core/Parameters/LoggingParameterType.cs
+++ b/Source/Vima.LoggingAbstractor.Core/Parameters/LoggingParameterType.cs
@@ -18,6 +18,11 @@
         /// <summary>
         /// The identity parameter.
         /// </summary>
-        Identity
+        Identity,
+
+        /// <summary>
+        /// The environment parameter.
+        /// </summary>
+        Environment
     }
 }

--- a/Source/Vima.LoggingAbstractor.Raygun/RaygunAbstractLogger.cs
+++ b/Source/Vima.LoggingAbstractor.Raygun/RaygunAbstractLogger.cs
@@ -83,8 +83,17 @@ namespace Vima.LoggingAbstractor.Raygun
 
         private static List<string> ExtractTags(IEnumerable<ILoggingParameter> loggingParameters, LoggingLevel loggingLevel)
         {
-            List<string> extractTags = loggingParameters.ExtractTags().ToList();
+            var parameters = loggingParameters.ToList();
+            var extractTags = parameters.ExtractTags().ToList();
+
             extractTags.Add(loggingLevel.ToString("G"));
+
+            var environment = parameters.ExtractEnvironment();
+            if (!string.IsNullOrEmpty(environment))
+            {
+                extractTags.Add(environment);
+            }
+
             return extractTags;
         }
 

--- a/Source/Vima.LoggingAbstractor.Sentry/SentryAbstractLogger.cs
+++ b/Source/Vima.LoggingAbstractor.Sentry/SentryAbstractLogger.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Sentry;
-using Sentry.Protocol;
 using Vima.LoggingAbstractor.Core;
 using Vima.LoggingAbstractor.Core.Extensions;
 using Vima.LoggingAbstractor.Core.Parameters;
@@ -88,6 +87,12 @@ namespace Vima.LoggingAbstractor.Sentry
             var scope = new Scope(new SentryOptions());
             scope.SetTags(tags);
             scope.Level = LoggingLevelMapper.ConvertLoggingLevelToSentryLevel(loggingLevel);
+
+            var environment = loggingParameters.ExtractEnvironment();
+            if (!string.IsNullOrEmpty(environment))
+            {
+                scope.Environment = environment;
+            }
 
             var identity = loggingParameters.ExtractIdentity();
             if (!string.IsNullOrEmpty(identity?.Identity))


### PR DESCRIPTION
This parameter is especially useful for Sentry logging where every project can have multiple environments with a nice separation between the logs.

Sentry: Set to the dedicated field in the scope.
AppInsight: Set as an "Environment" property.
Raygun: Set as a tag, to allow log filtering.

Fixes issue #24.